### PR TITLE
feat: Update parser-util version to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ configurations.all {
 }
 
 dependencies {
-    implementationExport(group: 'com.fortify.ssc.parser.util', name: 'fortify-ssc-parser-util-json', version:'2.1.1.RELEASE', changing: false) { transitive = true }
+    implementationExport(group: 'com.fortify.ssc.parser.util', name: 'fortify-ssc-parser-util-json', version:'3.0.1.RELEASE', changing: false) { transitive = true }
 }
 
 task copyMarkdown(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ configurations.all {
 }
 
 dependencies {
-    implementationExport(group: 'com.fortify.ssc.parser.util', name: 'fortify-ssc-parser-util-json', version:'1.6.1.RELEASE', changing: false) { transitive = true }
+    implementationExport(group: 'com.fortify.ssc.parser.util', name: 'fortify-ssc-parser-util-json', version:'2.1.1.RELEASE', changing: false) { transitive = true }
 }
 
 task copyMarkdown(type: Copy) {

--- a/src/main/java/com/fortify/ssc/parser/tenable/io/cs/TenableIoCsParserPlugin.java
+++ b/src/main/java/com/fortify/ssc/parser/tenable/io/cs/TenableIoCsParserPlugin.java
@@ -7,11 +7,13 @@ import org.slf4j.LoggerFactory;
 
 import com.fortify.plugin.api.ScanBuilder;
 import com.fortify.plugin.api.ScanData;
+import com.fortify.plugin.api.ScanEntry;
 import com.fortify.plugin.api.ScanParsingException;
 import com.fortify.plugin.api.VulnerabilityHandler;
 import com.fortify.plugin.spi.ParserPlugin;
 import com.fortify.ssc.parser.tenable.io.cs.parser.ScanParser;
 import com.fortify.ssc.parser.tenable.io.cs.parser.VulnerabilitiesParser;
+import com.fortify.util.ssc.parser.ScanEntryHelper;
 
 public class TenableIoCsParserPlugin implements ParserPlugin<CustomVulnAttribute> {
     private static final Logger LOG = LoggerFactory.getLogger(TenableIoCsParserPlugin.class);
@@ -33,11 +35,15 @@ public class TenableIoCsParserPlugin implements ParserPlugin<CustomVulnAttribute
 
     @Override
     public void parseScan(final ScanData scanData, final ScanBuilder scanBuilder) throws ScanParsingException, IOException {
-        new ScanParser(scanData, scanBuilder).parse();
+        new ScanParser(scanData, getScanEntry(scanData), scanBuilder).parse();
     }
 
 	@Override
 	public void parseVulnerabilities(final ScanData scanData, final VulnerabilityHandler vulnerabilityHandler) throws ScanParsingException, IOException {
-		new VulnerabilitiesParser(scanData, vulnerabilityHandler).parse();
+		new VulnerabilitiesParser(scanData, getScanEntry(scanData), vulnerabilityHandler).parse();
+	}
+
+	private final ScanEntry getScanEntry(final ScanData scanData) {
+		return ScanEntryHelper.getScanEntryByName(scanData, name -> name.endsWith(".json"));
 	}
 }

--- a/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/ScanParser.java
+++ b/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/ScanParser.java
@@ -23,7 +23,7 @@ public class ScanParser {
 			.handler("/image_name", jp -> scanBuilder.setBuildId(jp.getValueAsString()))
 			.handler("/tag", jp -> scanBuilder.setScanLabel(jp.getValueAsString()))
 			.handler("/installed_packages", jp -> scanBuilder.setNumFiles(jp.countArrayEntries()))
-			.parse(scanData);
+			.parse(scanData, scanData.getScanEntries().get(0));
 		scanBuilder.setEngineVersion("Unknown");
 		scanBuilder.completeScan();
 	}

--- a/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/ScanParser.java
+++ b/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/ScanParser.java
@@ -4,16 +4,19 @@ import java.io.IOException;
 
 import com.fortify.plugin.api.ScanBuilder;
 import com.fortify.plugin.api.ScanData;
+import com.fortify.plugin.api.ScanEntry;
 import com.fortify.plugin.api.ScanParsingException;
 import com.fortify.util.jackson.IsoDateTimeConverter;
 import com.fortify.util.ssc.parser.json.ScanDataStreamingJsonParser;
 
 public class ScanParser {
 	private final ScanData scanData;
+	private final ScanEntry scanEntry;
     private final ScanBuilder scanBuilder;
     
-	public ScanParser(final ScanData scanData, final ScanBuilder scanBuilder) {
+	public ScanParser(final ScanData scanData, final ScanEntry scanEntry, final ScanBuilder scanBuilder) {
 		this.scanData = scanData;
+		this.scanEntry = scanEntry;
 		this.scanBuilder = scanBuilder;
 	}
 	
@@ -23,7 +26,7 @@ public class ScanParser {
 			.handler("/image_name", jp -> scanBuilder.setBuildId(jp.getValueAsString()))
 			.handler("/tag", jp -> scanBuilder.setScanLabel(jp.getValueAsString()))
 			.handler("/installed_packages", jp -> scanBuilder.setNumFiles(jp.countArrayEntries()))
-			.parse(scanData, scanData.getScanEntries().get(0));
+			.parse(scanData, scanEntry);
 		scanBuilder.setEngineVersion("Unknown");
 		scanBuilder.completeScan();
 	}

--- a/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/VulnerabilitiesParser.java
+++ b/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/VulnerabilitiesParser.java
@@ -19,12 +19,12 @@ import com.fortify.ssc.parser.tenable.io.cs.CustomVulnAttribute;
 import com.fortify.ssc.parser.tenable.io.cs.domain.Finding;
 import com.fortify.ssc.parser.tenable.io.cs.domain.NvdFinding;
 import com.fortify.ssc.parser.tenable.io.cs.domain.Package;
-import com.fortify.util.ssc.parser.EngineTypeHelper;
+import com.fortify.util.ssc.parser.PluginXmlHelper;
 import com.fortify.util.ssc.parser.HandleDuplicateIdVulnerabilityHandler;
 import com.fortify.util.ssc.parser.json.ScanDataStreamingJsonParser;
 
 public class VulnerabilitiesParser {
-	private static final String ENGINE_TYPE = EngineTypeHelper.getEngineType();
+	private static final String ENGINE_TYPE = PluginXmlHelper.getPluginXmlDescriptor().getEngineType();
 	private final ScanData scanData;
 	private final VulnerabilityHandler vulnerabilityHandler;
 
@@ -41,7 +41,7 @@ public class VulnerabilitiesParser {
 	public final void parse() throws ScanParsingException, IOException {
 		new ScanDataStreamingJsonParser()
 			.handler("/findings/*", Finding.class, this::buildVulnerabilityIfValid)
-			.parse(scanData);
+			.parse(scanData, scanData.getScanEntries().get(0));
 	}
 	
 	/**

--- a/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/VulnerabilitiesParser.java
+++ b/src/main/java/com/fortify/ssc/parser/tenable/io/cs/parser/VulnerabilitiesParser.java
@@ -12,6 +12,7 @@ import com.fortify.plugin.api.BasicVulnerabilityBuilder.Priority;
 import com.fortify.plugin.api.FortifyAnalyser;
 import com.fortify.plugin.api.FortifyKingdom;
 import com.fortify.plugin.api.ScanData;
+import com.fortify.plugin.api.ScanEntry;
 import com.fortify.plugin.api.ScanParsingException;
 import com.fortify.plugin.api.StaticVulnerabilityBuilder;
 import com.fortify.plugin.api.VulnerabilityHandler;
@@ -26,10 +27,12 @@ import com.fortify.util.ssc.parser.json.ScanDataStreamingJsonParser;
 public class VulnerabilitiesParser {
 	private static final String ENGINE_TYPE = PluginXmlHelper.getPluginXmlDescriptor().getEngineType();
 	private final ScanData scanData;
+	private final ScanEntry scanEntry;
 	private final VulnerabilityHandler vulnerabilityHandler;
 
-    public VulnerabilitiesParser(final ScanData scanData, final VulnerabilityHandler vulnerabilityHandler) {
+    public VulnerabilitiesParser(final ScanData scanData, final ScanEntry scanEntry, final VulnerabilityHandler vulnerabilityHandler) {
     	this.scanData = scanData;
+		this.scanEntry = scanEntry;
 		this.vulnerabilityHandler = new HandleDuplicateIdVulnerabilityHandler(vulnerabilityHandler);
 	}
     
@@ -41,7 +44,7 @@ public class VulnerabilitiesParser {
 	public final void parse() throws ScanParsingException, IOException {
 		new ScanDataStreamingJsonParser()
 			.handler("/findings/*", Finding.class, this::buildVulnerabilityIfValid)
-			.parse(scanData, scanData.getScanEntries().get(0));
+			.parse(scanData, scanEntry);
 	}
 	
 	/**

--- a/src/test/java/com/fortify/ssc/parser/tenable/io/cs/TenableIoCsParserPluginTest.java
+++ b/src/test/java/com/fortify/ssc/parser/tenable/io/cs/TenableIoCsParserPluginTest.java
@@ -52,7 +52,7 @@ class TenableIoCsParserPluginTest {
 		
 		@Override
 		public List<ScanEntry> getScanEntries() {
-			return null;
+			return Arrays.asList(() -> "tenable.io-cs.json");
 		}
 		
 		@Override


### PR DESCRIPTION
Upgraded fortify-ssc-parser-util-json from 1.6.1 to 2.1.1.RELEASE. The new version changed the parse() signature to require a ScanEntry argument and renamed EngineTypeHelper to PluginXmlHelper. Updated parsers and test mock accordingly.